### PR TITLE
Fix for vault.centos.org now forces https TLS 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@
 
 On March 31, 2017, support of CentOS 5 has ended.
 And therefore, we cannot perform `yum` on CentOS 5 official images because yum repositories for CentOS 5 is deleted.
-This image rewrites yum repository urls in /etc/yum.repos.d to vault.centos.org.
+Since vault.centos.org forces https over tlsv3 which centos 511 doesn't support, use a pure http mirror that does not (yet) force https
+This image rewrites yum repository urls in /etc/yum.repos.d to http://linuxsoft.cern.ch/centos-vault/5.11/
 You can use this image as drop-in replacement of official `centos:5` (`centos:5.11`).

--- a/yum.repos.d/CentOS-Base.repo
+++ b/yum.repos.d/CentOS-Base.repo
@@ -2,37 +2,39 @@
 # CentOS-Base.repo
 #
 # Since official repositories are gone, use vault.centos.org instead.
+# Since vault.centos.org forces https over tlsv3 which centos 511 doesn't support
+# use a pure http mirror that does not (yet) force https
 #
 #
 
 [base]
 name=CentOS-5 - Base
-baseurl=http://vault.centos.org/5.11/os/$basearch/
+baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/os/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
 
 [updates]
 name=CentOS-5 - Updates
-baseurl=http://vault.centos.org/5.11/updates/$basearch/
+baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/updates/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
 
 [extras]
 name=CentOS-5 - Extras
-baseurl=http://vault.centos.org/5.11/extras/$basearch/
+baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/extras/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
 
 [centosplus]
 name=CentOS-5 - Plus
-baseurl=http://vault.centos.org/5.11/centosplus/$basearch/
+baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/centosplus/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
 
 [contrib]
 name=CentOS-5 - Contrib
-baseurl=http://vault.centos.org/5.11/contrib/$basearch/
+baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/contrib/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5

--- a/yum.repos.d/CentOS-Base.repo
+++ b/yum.repos.d/CentOS-Base.repo
@@ -9,32 +9,32 @@
 
 [base]
 name=CentOS-5 - Base
-baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/os/$basearch/
+baseurl=http://vault.epel.cloud/5.11/os/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
 
 [updates]
 name=CentOS-5 - Updates
-baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/updates/$basearch/
+baseurl=http://vault.epel.cloud/5.11/updates/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
 
 [extras]
 name=CentOS-5 - Extras
-baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/extras/$basearch/
+baseurl=http://vault.epel.cloud/5.11/extras/$basearch/
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
 
 [centosplus]
 name=CentOS-5 - Plus
-baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/centosplus/$basearch/
+baseurl=http://vault.epel.cloud/5.11/centosplus/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5
 
 [contrib]
 name=CentOS-5 - Contrib
-baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/contrib/$basearch/
+baseurl=http://vault.epel.cloud/5.11/contrib/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5

--- a/yum.repos.d/CentOS-fasttrack.repo
+++ b/yum.repos.d/CentOS-fasttrack.repo
@@ -2,7 +2,7 @@
 
 [fasttrack]
 name=CentOS-5 - fasttrack
-baseurl=http://vault.centos.org/5.11/fasttrack/$basearch/
+baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/fasttrack/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5

--- a/yum.repos.d/CentOS-fasttrack.repo
+++ b/yum.repos.d/CentOS-fasttrack.repo
@@ -2,7 +2,7 @@
 
 [fasttrack]
 name=CentOS-5 - fasttrack
-baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/fasttrack/$basearch/
+baseurl=http://vault.epel.cloud/5.11/fasttrack/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5

--- a/yum.repos.d/epel.repo
+++ b/yum.repos.d/epel.repo
@@ -1,0 +1,26 @@
+[epel]
+name=Extra Packages for Enterprise Linux 5 - $basearch
+baseurl=http://mirrors.kernel.org/fedora-buffet/archive/epel/5/$basearch
+#mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-5&arch=$basearch
+failovermethod=priority
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL
+
+[epel-debuginfo]
+name=Extra Packages for Enterprise Linux 5 - $basearch - Debug
+baseurl=http://mirrors.kernel.org/fedora-buffet/archive/epel/5/x86_64/$basearch/debug
+#mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-5&arch=$basearch
+failovermethod=priority
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL
+gpgcheck=1
+
+[epel-source]
+name=Extra Packages for Enterprise Linux 5 - $basearch - Source
+baseurl=http://mirrors.kernel.org/fedora-buffet/archive/epel/5/SRPMS
+#mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-5&arch=$basearch
+failovermethod=priority
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL
+gpgcheck=1

--- a/yum.repos.d/epel.repo
+++ b/yum.repos.d/epel.repo
@@ -1,24 +1,27 @@
 [epel]
 name=Extra Packages for Enterprise Linux 5 - $basearch
-baseurl=http://mirrors.kernel.org/fedora-buffet/archive/epel/5/$basearch
+#baseurl=http://mirrors.kernel.org/fedora-buffet/archive/epel/5/$basearch
+baseurl=http://ftp-stud.hs-esslingen.de/pub/Mirrors/archive.fedoraproject.org/epel/5/$basearch
 #mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-5&arch=$basearch
 failovermethod=priority
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL
 
-[epel-debuginfo]
-name=Extra Packages for Enterprise Linux 5 - $basearch - Debug
-baseurl=http://mirrors.kernel.org/fedora-buffet/archive/epel/5/x86_64/$basearch/debug
-#mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-5&arch=$basearch
-failovermethod=priority
-enabled=0
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL
-gpgcheck=1
-
+#[epel-debuginfo]
+#name=Extra Packages for Enterprise Linux 5 - $basearch - Debug
+##baseurl=http://mirrors.kernel.org/fedora-buffet/archive/epel/5/x86_64/$basearch/debug
+#baseurl=http://ftp-stud.hs-esslingen.de/pub/Mirrors/archive.fedoraproject.org/epel/5/x86_64/$basearch/debug
+##mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-5&arch=$basearch
+#failovermethod=priority
+#enabled=0
+#gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL
+#gpgcheck=1
+#
 [epel-source]
 name=Extra Packages for Enterprise Linux 5 - $basearch - Source
-baseurl=http://mirrors.kernel.org/fedora-buffet/archive/epel/5/SRPMS
+#baseurl=http://mirrors.kernel.org/fedora-buffet/archive/epel/5/SRPMS
+baseurl=http://ftp-stud.hs-esslingen.de/pub/Mirrors/archive.fedoraproject.org/epel/5/SRPMS
 #mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-5&arch=$basearch
 failovermethod=priority
 enabled=0

--- a/yum.repos.d/libselinux.repo
+++ b/yum.repos.d/libselinux.repo
@@ -2,7 +2,7 @@
 
 [libselinux]
 name=CentOS-5 - libselinux
-baseurl=http://vault.centos.org/5.11/centosplus/$basearch/
+baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/centosplus/$basearch/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5

--- a/yum.repos.d/libselinux.repo
+++ b/yum.repos.d/libselinux.repo
@@ -2,7 +2,7 @@
 
 [libselinux]
 name=CentOS-5 - libselinux
-baseurl=http://linuxsoft.cern.ch/centos-vault/5.11/centosplus/$basearch/
+baseurl=http://vault.epel.cloud/5.11/centosplus/$basearch/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-5


### PR DESCRIPTION
Since vault.centos.org forces https over tlsv1.3 which centos 511 doesn't support, use a pure http mirror that does not (yet) force https.